### PR TITLE
Add function to query store and return file list for given container ID

### DIFF
--- a/octopus/modules/store/store.py
+++ b/octopus/modules/store/store.py
@@ -208,6 +208,16 @@ class StoreJper(Store):
             return r.json()
         except:
             return ''
+        
+    def list_file_paths(self, container_id):
+        cpath = os.path.join(self.url, 'existing_files', container_id)
+        app.logger.info('Store - list_file_paths:' + container_id + ' ' + cpath)
+        r = requests.get(cpath)
+        try:
+            return r.json()
+        except:
+            return []
+
 
     def delete_backups(self, container_id, target_name):
         cpath = os.path.join(self.url, 'backup', container_id)

--- a/octopus/modules/store/store.py
+++ b/octopus/modules/store/store.py
@@ -210,7 +210,7 @@ class StoreJper(Store):
             return ''
         
     def list_file_paths(self, container_id):
-        cpath = os.path.join(self.url, 'existing_files', container_id)
+        cpath = os.path.join(self.url, 'list_files', container_id)
         app.logger.info('Store - list_file_paths:' + container_id + ' ' + cpath)
         r = requests.get(cpath)
         try:


### PR DESCRIPTION
Add a function which will query the store service using its REST api to return the physical location of the list of files that are saved in store for the given container ID. This is required for identifying and managing the files based on stakeholder requests.

This feature depends on the functionality added in store PR : https://github.com/OA-DeepGreen/store/pull/7
