### PR TITLE
Port in fixes from production system

### DIFF
--- a/octopus/modules/epmc/models.py
+++ b/octopus/modules/epmc/models.py
@@ -517,16 +517,14 @@ class JATS(object):
         # link 1: linked through xref element
         for xref in contrib.xpath('xref[@ref-type="aff"]'):
             rid = xref.get("rid")
-            found = self.xml.xpath("//aff[@id='" + rid + "']")
-            if found is not None and found[0] not in aff_elements: 
-                aff_elements.append(found[0])
+            for aff_el in self.xml.xpath("//aff[@id='" + rid + "']"):
+                aff_elements.append(aff_el)
 
         # link 2: linked via @rid attribute on contrib itself
         if contrib.get("rid") is not None:
             for rid in contrib.get("rid").split():
-                found = self.xml.xpath("//aff[@id='" + rid + "']")
-                if found is not None and found[0] not in aff_elements: 
-                    aff_elements.append(found[0])
+                for aff_el in self.xml.xpath("//aff[@id='" + rid + "']"):
+                    aff_elements.append(aff_el)
 
         # lastly: affs not directly related to contrib.
         # "global" aff elements that have no identifier

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@
 # (i.e. target this file with the -r switch on pip).
 
 # install esprit
--e git+https://github.com/OA-DeepGreen/esprit.git@b56f825af0715c7efa36de0e5dff4bc80418707d#egg=esprit
+-e git+https://github.com/OA-DeepGreen/esprit.git@ebead66bd64ff24172bd8aaccb9247576c45949c#egg=esprit


### PR DESCRIPTION
Two changes in this PR are

1. Update to the version of esprit used in requirements.txt to reflect the latest version
2. Port in a few fixes octopus/models/epmc/models.py that were implemented as hotfixes in the production system